### PR TITLE
Added toggle to make the time's font color white.

### DIFF
--- a/Battery Time Remaining/AppDelegate.h
+++ b/Battery Time Remaining/AppDelegate.h
@@ -22,6 +22,7 @@
 #define kBTRMenuEnergySaverSetting  9
 #define kBTRMenuUpdater             10
 #define kBTRMenuQuitKey             11
+#define kBTRMenuWhiteText           12
 
 #endif
 

--- a/Battery Time Remaining/AppDelegate.m
+++ b/Battery Time Remaining/AppDelegate.m
@@ -39,6 +39,7 @@ static void PowerSourceChanged(void * context)
     BOOL isOptionKeyPressed;
     BOOL isCapacityWarning;
     BOOL showParenthesis;
+    BOOL whiteText;
 }
 
 - (void)cacheBatteryIcon;
@@ -124,10 +125,18 @@ static void PowerSourceChanged(void * context)
     showParenthesis = [[NSUserDefaults standardUserDefaults] boolForKey:@"parentheses"];
     parenthesisSubmenuItem.state = (showParenthesis) ? NSOnState : NSOffState;
 
+    // Toggle Black & White Text
+    NSMenuItem *colorTextSubmenuItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"White Text Color", @"White Text Color") action:@selector(toggleTextColor:) keyEquivalent:@""];
+    [colorTextSubmenuItem setTag:kBTRMenuWhiteText];
+    colorTextSubmenuItem.target = self;
+    whiteText = [[NSUserDefaults standardUserDefaults] boolForKey:@"whiteText"];
+    colorTextSubmenuItem.state = (whiteText) ? NSOnState : NSOffState;
+    
     // Build the setting submenu
     NSMenu *settingSubmenu = [[NSMenu alloc] initWithTitle:@"Setting Menu"];
     [settingSubmenu addItem:advancedSubmenuItem];
     [settingSubmenu addItem:parenthesisSubmenuItem];
+    [settingSubmenu addItem:colorTextSubmenuItem];
 
     // Settings menu item
     NSMenuItem *settingMenu = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Settings", @"Settings menuitem") action:nil keyEquivalent:@""];
@@ -363,11 +372,18 @@ static void PowerSourceChanged(void * context)
     [self.statusItem setAlternateImage:[ImageFilter invertColor:image]];
 
     // Title
-    NSDictionary *attributedStyle = [NSDictionary dictionaryWithObjectsAndKeys:
-                                     // Font
-                                     [NSFont menuFontOfSize:12.0f],
-                                     NSFontAttributeName,
-                                     nil];
+    NSMutableDictionary *attributedStyle = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                             // Font
+                                             [NSFont menuFontOfSize:12.0f],
+                                             NSFontAttributeName,
+                                             nil];
+    
+    if(whiteText) {
+        [attributedStyle setObject:[NSColor whiteColor] forKey:NSForegroundColorAttributeName];
+    } else {
+        [attributedStyle setObject:[NSColor blackColor] forKey:NSForegroundColorAttributeName];
+    }
+    
 
     NSAttributedString *attributedTitle = [[NSAttributedString alloc] initWithString:title attributes:attributedStyle];
     self.statusItem.attributedTitle = attributedTitle;
@@ -570,6 +586,27 @@ static void PowerSourceChanged(void * context)
    [defaults synchronize];
 
    [self updateStatusItem];
+}
+
+- (void)toggleTextColor:(id)sender {
+    NSMenuItem     *item = sender;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    
+    if ([defaults boolForKey:@"whiteText"])
+    {
+        item.state = NSOffState;
+        whiteText = NO;
+        [defaults setBool:NO forKey:@"whiteText"];
+    }
+    else
+    {
+        item.state = NSOnState;
+        whiteText = YES;
+        [defaults setBool:YES forKey:@"whiteText"];
+    }
+    [defaults synchronize];
+    
+    [self updateStatusItem];
 }
 
 - (void)notify:(NSString *)message


### PR DESCRIPTION
I use the menu bar theme called Obsidian to make my menu bar black.  So I added a toggle with the option to make the time shown to the right of the battery white (the battery is automatically themed by Obsidian).

Signed-off-by: Johnny Johnny.Slagle@gmail.com
