### PR TITLE
Fixing the app forces activation of the discrete GPU on newer Macs.

### DIFF
--- a/Battery Time Remaining/Battery Time Remaining-Info.plist
+++ b/Battery Time Remaining/Battery Time Remaining-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
This fixes the app forcing the use of the discrete graphics card in OSX Mavericks (issue #74).
